### PR TITLE
TST: test every supported Python version on ubuntu, but only edges on OsX and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [
-          ubuntu-latest,
-          macos-latest,
-          windows-latest,
-        ]
+        os: [ubuntu-latest]
         python-version: [
           "3.6",
           "3.7",
@@ -25,7 +21,16 @@ jobs:
           "3.9",
           #"3.10-dev"
         ]
-
+        include:
+          # only test oldest and most recent Python on other platforms
+          - os: macos-latest
+            python-version: '3.6'
+          - os: macos-latest
+            python-version: '3.9'
+          - os: windows-latest
+            python-version: '3.6'
+          - os: windows-latest
+            python-version: '3.9'
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout Source


### PR DESCRIPTION
Apparently MacOS builds are scarce now, let's not test every single Python version on every platform