### PR TITLE
REL: cmyt 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ version will be considered major. If you're developing a library that depends on
 cmyt, we recommend to set an explicit upper limit as well as a minimal one in
 your requirements as for instance
 ```
-cmyt >= 0.1.1, < 1.0.0
+cmyt >= 1.0.1, < 2.0.0
 ```
 with the minimal required version pointing to the e.g. the last colormap
 addition your need, and the upper limit preventing your CI to upgrade to a major

--- a/cmyt/__init__.py
+++ b/cmyt/__init__.py
@@ -1,3 +1,3 @@
 from .cm import *
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     matplotlib>=2.1.0
     more-itertools>=8.4
     numpy>=1.13.3
-    typing_extensions>=3.10.0.2
+    typing_extensions>=3.10.0.2;python_version < "3.8"
 python_requires = >=3.6
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cmyt
-version = 1.0.0
+version = 1.0.1
 description = A collection of Matplotlib colormaps from the yt project
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
- MNT: drop unneeded dependency on typing_extensions for Python >= 3.8
- REL: bump version number to 1.0.1
