### PR TITLE
TST: configure matplotlib in test to use a non-graphical backend

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -44,7 +44,6 @@ jobs:
 
     - name: Run test suite
       run: |
-        export MPLBACKEND=Agg
         pytest --mpl-results-path=test_results -Werror
 
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,6 @@ jobs:
         python3 -m pip install -e .[dev]
     - name: Run test suite
       run: |
-        export MPLBACKEND=Agg
         pytest --mpl-results-path=test_results
     - uses: actions/upload-artifact@v2
       if: failure()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import matplotlib
+
+
+def pytest_configure(config):
+    matplotlib.use("Agg")


### PR DESCRIPTION
migrate config from github workflows to conftest.py