### PR TITLE
MNT: drop support for Python 3.6 and 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: [
-          "3.6",
-          "3.7",
           "3.8",
           "3.9",
           '3.10',
@@ -24,11 +22,11 @@ jobs:
         include:
           # only test oldest and most recent Python on other platforms
           - os: macos-latest
-            python-version: '3.6'
+            python-version: '3.8'
           - os: macos-latest
             python-version: '3.10'
           - os: windows-latest
-            python-version: '3.6'
+            python-version: '3.8'
           - os: windows-latest
             python-version: '3.10'
     runs-on: ${{ matrix.os }}
@@ -59,7 +57,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.6
+        python-version: '3.8'
     - name: Setup package
       run: |
         python3 -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     rev: v2.34.0
     hooks:
     - id: pyupgrade
-      args: [--py36-plus]
+      args: [--py38-plus]
 -   repo: https://github.com/asottile/reorder_python_imports
     rev: v3.3.0
     hooks:

--- a/cmyt/utils.py
+++ b/cmyt/utils.py
@@ -2,7 +2,9 @@ import os
 import re
 import sys
 from typing import Dict
+from typing import Final
 from typing import Iterable
+from typing import Literal
 from typing import Optional
 from typing import Tuple
 
@@ -17,12 +19,6 @@ from matplotlib.figure import Figure
 from more_itertools import always_iterable
 
 # type aliases
-if sys.version_info >= (3, 8):
-    from typing import Final
-    from typing import Literal
-else:
-    from typing_extensions import Final
-    from typing_extensions import Literal
 
 _CMYT_PREFIX: Final[str] = "cmyt."
 PrimaryColorName = Literal["blue", "green", "red"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ addopts = "--doctest-modules"
 
 
 [tool.mypy]
-python_version = "3.6"
+python_version = "3.8"
 warn_unused_configs = true
 warn_unused_ignores = true
 warn_unreachable = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,8 +19,6 @@ classifiers =
     Operating System :: POSIX :: Linux
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -36,11 +34,10 @@ project_urls =
 packages = find:
 install_requires =
     colorspacious>=1.1.2
-    matplotlib>=2.1.0
+    matplotlib>=3.2.0
     more-itertools>=8.4
-    numpy>=1.13.3
-    typing-extensions>=3.10.0.2;python_version < "3.8"
-python_requires = >=3.6
+    numpy>=1.17.4
+python_requires = >=3.8
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
Python 3.6 is EOL, and currently stands in the way of an important improvement, so let's drop it.
