### PR TITLE
MNT: use a version of Python we actually support for PyPI publications

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.6
+          python-version: '3.10'
       - name: Install build dependencies
         run: python3 -m pip install build wheel
       - name: Build distributions


### PR DESCRIPTION
Weirdly, version 1.1.0 seems to have been compiled and uploaded correctly, but I'll rest easier knowing this won't happen again.
edit: actually v1.1.0 may be corrupted so I'll yank it and do a v1.1.1