### PR TITLE
BUG: fix compatibility for matplotlib 3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/cmyt.svg?logo=pypi&logoColor=white&label=PyPI)](https://pypi.org/project/cmyt)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/cmyt.svg?logo=condaforge&logoColor=white)](https://anaconda.org/conda-forge/cmyt)
-[![Supported Python Versions](https://img.shields.io/pypi/pyversions/cmyt?v1.1.1&logo=python&logoColor=white&label=Python)](https://pypi.org/project/cmyt/)
+[![Supported Python Versions](https://img.shields.io/pypi/pyversions/cmyt?v1.1.2&logo=python&logoColor=white&label=Python)](https://pypi.org/project/cmyt/)
 
 [![CI](https://github.com/yt-project/cmyt/actions/workflows/ci.yml/badge.svg)](https://github.com/yt-project/cmyt/actions/workflows/ci.yml)
 [![CI (bleeding edge)](https://github.com/yt-project/cmyt/actions/workflows/bleeding-edge.yaml/badge.svg)](https://github.com/yt-project/cmyt/actions/workflows/bleeding-edge.yaml)

--- a/cmyt/__init__.py
+++ b/cmyt/__init__.py
@@ -1,3 +1,3 @@
 from .cm import *
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"

--- a/cmyt/utils.py
+++ b/cmyt/utils.py
@@ -95,7 +95,9 @@ def _register_mpl_cmap(cmap: Colormap) -> None:
     if MPL_VERSION >= (3, 5, 0):
         matplotlib.colormaps.register(cmap)
     else:
-        matplotlib.cm.register_cmap(cmap=cmap)
+        from matplotlib.cm import register_cmap
+
+        register_cmap(cmap=cmap)
 
 
 def register_colormap(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cmyt
-version = 1.1.1
+version = 1.1.2
 description = A collection of Matplotlib colormaps from the yt project
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Close #81
Still don't know why the problem wasn't caught earlier, I assume it was because minimal env tests are only done on Linux and I discovered the issue on MacOS.