### PR TITLE
TST: diminish verbosity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Setup package
       run: |
-        python3 -m pip install --upgrade pip
-        python3 -m pip install .[dev]
+        python -m pip install --upgrade pip
+        python -m pip install .[dev]
     - name: Run test suite
-      run: pytest
+      run: pytest --color yes
     - uses: actions/upload-artifact@v2
       if: failure()
       with:
@@ -66,7 +66,7 @@ jobs:
         python scripts/hardpin_minimal_dependencies.py
         python -m pip install -e .[dev]
     - name: Run test suite
-      run: pytest
+      run: pytest --color yes
 
   image_tests:
     runs-on: ubuntu-latest
@@ -78,11 +78,11 @@ jobs:
         python-version: '3.10'
 
     - name: Setup package
-      run: python3 -m pip install ".[dev]"
+      run: python -m pip install ".[dev]"
 
     - name: Run image tests
       run: |
-        pytest -vvv --mpl --mpl-generate-summary=html --mpl-results-path=mpl_results
+        pytest --color yes -v --mpl --mpl-generate-summary=html --mpl-results-path=mpl_results
 
     - name: Upload pytest-mpl report
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
Currently, both mpl and PIL's loggers are set to DEBUG mode in CI, generating quite a lot of noise. I think this is due to excessive verbosity in pytest, let's start with a noop change to set a baseline.
