### PR TITLE
DEP: drop support for matplotlib<3.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ keywords = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "matplotlib>=3.2.0",
+    "matplotlib>=3.5.0",
     "numpy>=1.17.4",
 ]
 


### PR DESCRIPTION
this should be okay now that yt (dev) requires matplotlib>=3.5 (https://github.com/yt-project/yt/pull/4521)

Also avoid unnecessary copies (`matplotlib.colormaps.register` always copies inputs, so we don't need an extra copy to safely modify a colormap). This makes cmyt finally negligible in terms of startup overhead in `import yt` (going from 4% to <0.8%).
