### PR TITLE
DEP: make colorspacious a test-only dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ keywords = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "colorspacious>=1.1.2",
     "matplotlib>=3.2.0",
     "numpy>=1.17.4",
 ]

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,2 +1,3 @@
 pytest>=6.2.4
 pytest-mpl>=0.13
+colorspacious>=1.1.2


### PR DESCRIPTION
Colorspacious hasn't had a single release in 5 years, and no activity in 4. While remarkably stable, it's only used in a utility function (not the public API), it seems preferable to make it a test-only dependency so any future breaking change from CPython will not impact our users.