### PR TITLE
TST: move tests to Python 3.12 (stable)

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -32,15 +32,14 @@ jobs:
     - name: Set up Python Dev Version
       uses: actions/setup-python@v4
       with:
-        python-version: 3.11-dev
+        python-version: 3.12-dev
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools wheel
-        python -m pip install --pre \
-          --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
-          numpy matplotlib
+        python -m pip install --pre --only-binary ":all:" numpy matplotlib \
+          --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 
     - name: Build library
       run: |
@@ -49,7 +48,7 @@ jobs:
 
     - name: Run test suite
       run: |
-        pytest --color yes --mpl-results-path=test_results -Werror
+        pytest --color yes --mpl-results-path=test_results
 
     - uses: actions/upload-artifact@v3
       if: failure()

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: 3.x
     - name: Install build dependencies
       run: python -m pip install build wheel
     - name: Build distributions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,17 +19,17 @@ jobs:
         - '3.9'
         - '3.10'
         - '3.11'
-        - 3.12-dev
+        - '3.12'
         include:
           # only test oldest and most recent Python on other platforms
         - os: macos-latest
           python-version: '3.9'
         - os: macos-latest
-          python-version: '3.11'
+          python-version: '3.12'
         - os: windows-latest
           python-version: '3.9'
         - os: windows-latest
-          python-version: '3.11'
+          python-version: '3.12'
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout Source
@@ -84,7 +84,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: 3.x
 
     - name: Build library
       run: |
@@ -131,7 +131,7 @@ jobs:
         python-version:
         # oldest and newest supported versions
         - '3.9'
-        - '3.11'
+        - '3.12'
     concurrency:
       # auto-cancel any in-progress job *on the same branch*
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.python-version }}-typecheck

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,9 +88,7 @@ ignore_errors = true
 [tool.pytest.ini_options]
 filterwarnings = [
     "error",
-    # already patched (but not released) upstream:
-    # https://github.com/dateutil/dateutil/pull/1285
-    'ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated and scheduled for removal in a future version:DeprecationWarning',
+    'ignore:datetime\.datetime\.utcfromtimestamp\(\) is deprecated:DeprecationWarning', # https://github.com/dateutil/dateutil/pull/1285
 ]
 addopts = "--doctest-modules"
 testpaths = ["tests"]


### PR DESCRIPTION
anticipating on the incoming release (I'm issuing a bunch of similar PRs on many projects now so I can just push buttons on the day it actually works)
