### PR TITLE
Add colorspacious as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ requires-python = ">=3.9"
 dependencies = [
     "matplotlib>=3.5.0",
     "numpy>=1.19.3",
+    "colorspacious",
 ]
 dynamic = ["version"]
 
@@ -53,6 +54,7 @@ include-package-data = false
 
 [tool.setuptools.packages.find]
 namespaces = false
+exclude = ["tests"]
 
 [tool.ruff]
 exclude = ["*__init__.py"]


### PR DESCRIPTION
Add colorspacious as dependency. It is imported in `cmyt.utils` and exclude tests from installation