### PR TITLE
MNT: rename private module to clarify that it's not part of public API

### DIFF
--- a/cmyt/_utils.py
+++ b/cmyt/_utils.py
@@ -51,7 +51,7 @@ def unprefix_name(name: str) -> str:
     'arbre'
     """
     warnings.warn(
-        "cmyt.utils.unprefix_name is deprecated since version 1.4.0 "
+        "cmyt._utils.unprefix_name is deprecated since version 1.4.0 "
         "and will be removed in a future version. "
         "Instead, use name.removeprefix('cmyt.')",
         category=DeprecationWarning,

--- a/cmyt/cm.py
+++ b/cmyt/cm.py
@@ -1,6 +1,6 @@
 from importlib import import_module
 
-from cmyt.utils import cmyt_cmaps, register_colormap
+from cmyt._utils import cmyt_cmaps, register_colormap
 
 for name in cmyt_cmaps:
     # register to MPL

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytest
 
 import cmyt
-from cmyt.utils import cmyt_cmaps, prefix_name
+from cmyt._utils import cmyt_cmaps, prefix_name
 
 mpl_compare = pytest.mark.mpl_image_compare(
     savefig_kwargs={"bbox_inches": "tight"},

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 
 import cmyt  # noqa: F401
-from cmyt.utils import create_cmap_overview
+from cmyt._utils import create_cmap_overview
 
 mpl_compare = pytest.mark.mpl_image_compare(
     savefig_kwargs={"bbox_inches": "tight"},


### PR DESCRIPTION
In response to #149 