### PR TITLE
DEP: drop support for matplotlib<3.8 and numpy<1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
           venv-loc: Script
         - os: ubuntu-20.04
           python-version: '3.10'
-          # 2022-03-27 is setuptool 61.2's release date
-          install-args: --resolution=lowest-direct --exclude-newer '2022-03-27'
+          # 2023-09-15 is numpy 1.26.0's release date
+          install-args: --resolution=lowest-direct --exclude-newer '2023-09-16'
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ keywords = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "matplotlib>=3.5.1",
-    "numpy>=1.22.3, <3",
+    "matplotlib>=3.8.0",
+    "numpy>=1.26.0, <3",
 ]
 
 [project.license]


### PR DESCRIPTION
in support to #189